### PR TITLE
feat: add MiniMax as LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ AIDEEPIN
 | Ollama   | ✓   |        |      |        |          |          |         |             |
 | DeepSeek | ✓   |        |      |        |          |          |         |             |
 | 千帆       | ✓   |        |      |        |          |          |         |             |
+| MiniMax  | ✓   |        |      |        |          |          |         |             |
 
 ## 技术栈
 
@@ -124,6 +125,9 @@ ps: neo4j 与 pgvector + apache age 二选一即可
 
     -- ollama的配置
     update adi_model_platform set base_url = 'my_ollama_base_url' where name = 'ollama';
+
+    -- MiniMax的配置
+    update adi_model_platform set api_key = 'my_minimax_api_key' where name = 'minimax';
     ```
   + 启用模型平台下的模型或新增模型
 
@@ -136,6 +140,7 @@ ps: neo4j 与 pgvector + apache age 二选一即可
     update adi_ai_model set is_enable = true where name = 'THUDM/GLM-Z1-9B-0414';
     update adi_ai_model set is_enable = true where name = 'ernie_speed';
     update adi_ai_model set is_enable = true where name = 'tinydolphin';
+    update adi_ai_model set is_enable = true where name = 'MiniMax-M2.7';
 
     -- Add new model
     INSERT INTO adi_ai_model (name, type, platform, is_enable) VALUES ('vicuna', 'text', 'ollama', true);

--- a/README_en.md
+++ b/README_en.md
@@ -65,6 +65,7 @@ Frontend projects:
 | Ollama         | ✓    |                  |    |                 |          |          |         |                               |
 | DeepSeek       | ✓    |                  |     |                 |          |          |         |                               |
 | Qianfan        | ✓    |                  |     |                 |          |          |         |                               |
+| MiniMax        | ✓    |                  |     |                 |          |          |         |                               |
 
 ## Tech Stack
 
@@ -120,6 +121,9 @@ Frontend tech stack:
   
       -- Ollama configuration
       update adi_model_platform set base_url = 'my_ollama_base_url' where name = 'ollama';
+
+      -- MiniMax configuration
+      update adi_model_platform set api_key = 'my_minimax_api_key' where name = 'minimax';
       ```
     * Enable model platform models or add new models
       ```
@@ -131,6 +135,7 @@ Frontend tech stack:
       update adi_ai_model set is_enable = true where name = 'THUDM/GLM-Z1-9B-0414';
       update adi_ai_model set is_enable = true where name = 'ernie_speed';
       update adi_ai_model set is_enable = true where name = 'tinydolphin';
+      update adi_ai_model set is_enable = true where name = 'MiniMax-M2.7';
   
       -- Add new model
       INSERT INTO adi_ai_model (name, type, platform, is_enable) VALUES ('vicuna', 'text', 'ollama', true);

--- a/adi-common/src/main/java/com/moyz/adi/common/cosntant/AdiConstant.java
+++ b/adi-common/src/main/java/com/moyz/adi/common/cosntant/AdiConstant.java
@@ -183,6 +183,7 @@ public class AdiConstant {
         public static final String QIANFAN = "qianfan";
         public static final String OLLAMA = "ollama";
         public static final String SILICONFLOW = "siliconflow";
+        public static final String MINIMAX = "minimax";
 
         // 获取所有公共静态常量（String类型的值）的列表
         public static List<String> getModelConstants() {

--- a/adi-common/src/main/java/com/moyz/adi/common/languagemodel/MinimaxLLMService.java
+++ b/adi-common/src/main/java/com/moyz/adi/common/languagemodel/MinimaxLLMService.java
@@ -1,0 +1,19 @@
+package com.moyz.adi.common.languagemodel;
+
+import com.moyz.adi.common.entity.AiModel;
+import com.moyz.adi.common.entity.ModelPlatform;
+import lombok.experimental.Accessors;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * MiniMax LLM service
+ * MiniMax API is compatible with OpenAI API format
+ * <a href="https://platform.minimaxi.com/document/introduction">MiniMax API Documentation</a>
+ */
+@Slf4j
+@Accessors(chain = true)
+public class MinimaxLLMService extends OpenAiLLMService {
+    public MinimaxLLMService(AiModel model, ModelPlatform modelPlatform) {
+        super(model, modelPlatform);
+    }
+}

--- a/adi-common/src/main/java/com/moyz/adi/common/service/AiModelInitializer.java
+++ b/adi-common/src/main/java/com/moyz/adi/common/service/AiModelInitializer.java
@@ -101,6 +101,9 @@ public class AiModelInitializer {
 
         // 硅基流动
         initLLMService(AdiConstant.ModelPlatform.SILICONFLOW, modelType, model -> new SiliconflowLLMService(model, nameToPlatform.get(AdiConstant.ModelPlatform.SILICONFLOW)));
+
+        // MiniMax
+        initLLMService(AdiConstant.ModelPlatform.MINIMAX, modelType, model -> new MinimaxLLMService(model, nameToPlatform.get(AdiConstant.ModelPlatform.MINIMAX)).setProxyAddress(proxyAddress));
     }
 
     /**

--- a/adi-common/src/test/java/com/moyz/adi/common/languagemodel/MinimaxLLMServiceIntegrationTest.java
+++ b/adi-common/src/test/java/com/moyz/adi/common/languagemodel/MinimaxLLMServiceIntegrationTest.java
@@ -1,0 +1,78 @@
+package com.moyz.adi.common.languagemodel;
+
+import com.moyz.adi.common.cosntant.AdiConstant;
+import com.moyz.adi.common.entity.AiModel;
+import com.moyz.adi.common.entity.ModelPlatform;
+import com.moyz.adi.common.util.LocalCache;
+import com.moyz.adi.common.vo.ChatModelBuilderProperties;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for MinimaxLLMService.
+ * These tests require a valid MINIMAX_API_KEY environment variable.
+ */
+@EnabledIfEnvironmentVariable(named = "MINIMAX_API_KEY", matches = ".+")
+class MinimaxLLMServiceIntegrationTest {
+
+    private MinimaxLLMService service;
+    private ChatModelBuilderProperties builderProperties;
+
+    @BeforeEach
+    void setUp() {
+        // Populate required TTS config in LocalCache so AbstractLLMService constructor succeeds
+        LocalCache.CONFIGS.put(AdiConstant.SysConfigKey.TTS_SETTING,
+                "{\"synthesizer_side\":\"client\",\"model_name\":\"cosyvoice-v2\",\"platform\":\"dashscope\"}");
+
+        ModelPlatform modelPlatform = new ModelPlatform();
+        modelPlatform.setId(1L);
+        modelPlatform.setName(AdiConstant.ModelPlatform.MINIMAX);
+        modelPlatform.setTitle("MiniMax");
+        modelPlatform.setBaseUrl("https://api.minimax.io/v1");
+        modelPlatform.setApiKey(System.getenv("MINIMAX_API_KEY"));
+        modelPlatform.setIsProxyEnable(false);
+        modelPlatform.setIsOpenaiApiCompatible(false);
+
+        AiModel aiModel = new AiModel();
+        aiModel.setId(1L);
+        aiModel.setName("MiniMax-M2.5-highspeed");
+        aiModel.setTitle("MiniMax-M2.5-highspeed");
+        aiModel.setType(AdiConstant.ModelType.TEXT);
+        aiModel.setPlatform(AdiConstant.ModelPlatform.MINIMAX);
+        aiModel.setIsEnable(true);
+        aiModel.setContextWindow(204000);
+        aiModel.setMaxInputTokens(180000);
+        aiModel.setMaxOutputTokens(24000);
+        aiModel.setResponseFormatTypes("text,json_object");
+
+        service = new MinimaxLLMService(aiModel, modelPlatform);
+
+        builderProperties = new ChatModelBuilderProperties();
+        builderProperties.setTemperature(0.7);
+    }
+
+    @Test
+    void testBuildChatModel() {
+        ChatModel chatModel = service.buildChatLLM(builderProperties);
+        assertNotNull(chatModel);
+    }
+
+    @Test
+    void testBuildStreamingChatModel() {
+        StreamingChatModel streamingChatModel = service.buildStreamingChatModel(builderProperties);
+        assertNotNull(streamingChatModel);
+    }
+
+    @Test
+    void testChatModelResponse() {
+        ChatModel chatModel = service.buildChatLLM(builderProperties);
+        String response = chatModel.chat("Say hello in one word");
+        assertNotNull(response);
+        assertFalse(response.isEmpty());
+    }
+}

--- a/adi-common/src/test/java/com/moyz/adi/common/languagemodel/MinimaxLLMServiceTest.java
+++ b/adi-common/src/test/java/com/moyz/adi/common/languagemodel/MinimaxLLMServiceTest.java
@@ -1,0 +1,135 @@
+package com.moyz.adi.common.languagemodel;
+
+import com.moyz.adi.common.cosntant.AdiConstant;
+import com.moyz.adi.common.entity.AiModel;
+import com.moyz.adi.common.entity.ModelPlatform;
+import com.moyz.adi.common.util.LocalCache;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for MinimaxLLMService
+ */
+class MinimaxLLMServiceTest {
+
+    private AiModel aiModel;
+    private ModelPlatform modelPlatform;
+
+    @BeforeEach
+    void setUp() {
+        // Populate required TTS config in LocalCache so AbstractLLMService constructor succeeds
+        LocalCache.CONFIGS.put(AdiConstant.SysConfigKey.TTS_SETTING,
+                "{\"synthesizer_side\":\"client\",\"model_name\":\"cosyvoice-v2\",\"platform\":\"dashscope\"}");
+
+        modelPlatform = new ModelPlatform();
+        modelPlatform.setId(1L);
+        modelPlatform.setName(AdiConstant.ModelPlatform.MINIMAX);
+        modelPlatform.setTitle("MiniMax");
+        modelPlatform.setBaseUrl("https://api.minimax.io/v1");
+        modelPlatform.setApiKey("test-api-key");
+        modelPlatform.setIsProxyEnable(false);
+        modelPlatform.setIsOpenaiApiCompatible(false);
+
+        aiModel = new AiModel();
+        aiModel.setId(1L);
+        aiModel.setName("MiniMax-M2.7");
+        aiModel.setTitle("MiniMax-M2.7");
+        aiModel.setType(AdiConstant.ModelType.TEXT);
+        aiModel.setPlatform(AdiConstant.ModelPlatform.MINIMAX);
+        aiModel.setIsEnable(true);
+        aiModel.setContextWindow(1000000);
+        aiModel.setMaxInputTokens(900000);
+        aiModel.setMaxOutputTokens(100000);
+        aiModel.setResponseFormatTypes("text,json_object");
+    }
+
+    @Test
+    void testMinimaxLLMServiceCreation() {
+        MinimaxLLMService service = new MinimaxLLMService(aiModel, modelPlatform);
+        assertNotNull(service);
+    }
+
+    @Test
+    void testMinimaxLLMServiceIsEnabled() {
+        MinimaxLLMService service = new MinimaxLLMService(aiModel, modelPlatform);
+        assertTrue(service.isEnabled());
+    }
+
+    @Test
+    void testMinimaxLLMServiceIsDisabledWithoutApiKey() {
+        modelPlatform.setApiKey("");
+        MinimaxLLMService service = new MinimaxLLMService(aiModel, modelPlatform);
+        assertFalse(service.isEnabled());
+    }
+
+    @Test
+    void testMinimaxLLMServiceIsDisabledWithNullApiKey() {
+        modelPlatform.setApiKey(null);
+        MinimaxLLMService service = new MinimaxLLMService(aiModel, modelPlatform);
+        assertFalse(service.isEnabled());
+    }
+
+    @Test
+    void testMinimaxLLMServiceIsDisabledWhenModelDisabled() {
+        aiModel.setIsEnable(false);
+        MinimaxLLMService service = new MinimaxLLMService(aiModel, modelPlatform);
+        assertFalse(service.isEnabled());
+    }
+
+    @Test
+    void testMinimaxLLMServiceExtendsOpenAiLLMService() {
+        MinimaxLLMService service = new MinimaxLLMService(aiModel, modelPlatform);
+        assertInstanceOf(OpenAiLLMService.class, service);
+    }
+
+    @Test
+    void testMinimaxLLMServiceExtendsAbstractLLMService() {
+        MinimaxLLMService service = new MinimaxLLMService(aiModel, modelPlatform);
+        assertInstanceOf(AbstractLLMService.class, service);
+    }
+
+    @Test
+    void testMinimaxLLMServiceSetProxyAddressChaining() {
+        MinimaxLLMService service = new MinimaxLLMService(aiModel, modelPlatform);
+        AbstractLLMService result = service.setProxyAddress(null);
+        assertSame(service, result);
+    }
+
+    @Test
+    void testMinimaxLLMServiceTokenEstimator() {
+        MinimaxLLMService service = new MinimaxLLMService(aiModel, modelPlatform);
+        // MiniMax uses OpenAI-compatible token estimator (falls back to GPT-3.5 turbo)
+        assertNotNull(service.getTokenEstimator());
+    }
+
+    @Test
+    void testMinimaxLLMServiceWithM25Model() {
+        aiModel.setName("MiniMax-M2.5");
+        aiModel.setTitle("MiniMax-M2.5");
+        MinimaxLLMService service = new MinimaxLLMService(aiModel, modelPlatform);
+        assertTrue(service.isEnabled());
+    }
+
+    @Test
+    void testMinimaxLLMServiceWithM25HighspeedModel() {
+        aiModel.setName("MiniMax-M2.5-highspeed");
+        aiModel.setTitle("MiniMax-M2.5-highspeed");
+        aiModel.setContextWindow(204000);
+        aiModel.setMaxInputTokens(180000);
+        aiModel.setMaxOutputTokens(24000);
+        MinimaxLLMService service = new MinimaxLLMService(aiModel, modelPlatform);
+        assertTrue(service.isEnabled());
+    }
+
+    @Test
+    void testModelPlatformMinimaxConstant() {
+        assertEquals("minimax", AdiConstant.ModelPlatform.MINIMAX);
+    }
+
+    @Test
+    void testModelPlatformConstantsContainMinimax() {
+        assertTrue(AdiConstant.ModelPlatform.getModelConstants().contains("minimax"));
+    }
+}

--- a/docs/create.sql
+++ b/docs/create.sql
@@ -1057,6 +1057,8 @@ insert into adi_model_platform (name, title, base_url)
 values ('ollama', 'ollama', 'http://localhost:11434');
 insert into adi_model_platform (name, title, base_url)
 values ('qianfan', '千帆', '');
+insert into adi_model_platform (name, title, base_url)
+values ('minimax', 'MiniMax', 'https://api.minimax.io/v1');
 
 -- 硅基流动的文本模型的api兼容 openai api，本行数据用来测试动态创建的模型平台及模型是否正常使用了 OpenAiCompatibleLLMService 进行请求
 insert into adi_model_platform (name, title, base_url, is_openai_api_compatible)
@@ -1560,6 +1562,17 @@ INSERT INTO adi_ai_model (name, title, type, platform, context_window, max_input
                           setting)
 VALUES ('ERNIE-Speed-128K', 'ernie_speed', 'text', 'qianfan', 131072, 126976, 4096, true, false,
         '{"endpoint":"ernie-speed-128k"}');
+-- https://platform.minimaxi.com/document/models
+INSERT INTO adi_ai_model (name, title, type, platform, context_window, max_input_tokens, max_output_tokens,
+                          response_format_types, is_enable)
+VALUES ('MiniMax-M2.7', 'MiniMax-M2.7', 'text', 'minimax', 1000000, 900000, 100000, 'text,json_object', false);
+INSERT INTO adi_ai_model (name, title, type, platform, context_window, max_input_tokens, max_output_tokens,
+                          response_format_types, is_enable)
+VALUES ('MiniMax-M2.5', 'MiniMax-M2.5', 'text', 'minimax', 1000000, 900000, 100000, 'text,json_object', false);
+INSERT INTO adi_ai_model (name, title, type, platform, context_window, max_input_tokens, max_output_tokens,
+                          response_format_types, remark, is_enable)
+VALUES ('MiniMax-M2.5-highspeed', 'MiniMax-M2.5-highspeed', 'text', 'minimax', 204000, 180000, 24000, 'text,json_object',
+        '高速版本，适合低延迟场景 | High-speed version, suitable for low-latency scenarios', false);
 INSERT INTO adi_ai_model (name, title, type, platform, is_enable)
 VALUES ('tinydolphin', 'ollama-tinydolphin', 'text', 'ollama', false);
 INSERT INTO adi_ai_model (name, title, type, platform, response_format_types, remark, is_free, is_enable)


### PR DESCRIPTION
## Summary

Add [MiniMax](https://platform.minimaxi.com) as a first-class LLM provider, following the same OpenAI-compatible pattern as DeepSeek and SiliconFlow.

### Changes

- **`AdiConstant.ModelPlatform`**: Add `MINIMAX = "minimax"` constant
- **`MinimaxLLMService`**: New service class extending `OpenAiLLMService` (MiniMax API is OpenAI-compatible)
- **`AiModelInitializer`**: Register MiniMax provider in the LLM service initialization pipeline
- **`docs/create.sql`**: Add `adi_model_platform` and `adi_ai_model` init records:
  - MiniMax-M2.7 (1M context window)
  - MiniMax-M2.5 (1M context window)
  - MiniMax-M2.5-highspeed (204K context, low-latency)
- **`README.md` / `README_en.md`**: Add MiniMax to the integrated platform feature table and deployment configuration docs

### Tests

- 13 unit tests (`MinimaxLLMServiceTest`)
- 3 integration tests (`MinimaxLLMServiceIntegrationTest`, gated by `MINIMAX_API_KEY` env var)

### MiniMax API

- Base URL: `https://api.minimax.io/v1`
- OpenAI-compatible chat completions endpoint
- Models: M2.7 (latest), M2.5, M2.5-highspeed
- [API Documentation](https://platform.minimaxi.com/document/introduction)

### How to enable

```sql
-- Configure MiniMax API key
UPDATE adi_model_platform SET api_key = 'your_minimax_api_key' WHERE name = 'minimax';

-- Enable MiniMax models
UPDATE adi_ai_model SET is_enable = true WHERE name = 'MiniMax-M2.7';
```