### PR TITLE
fix(knowledge-base): authorize the read endpoints (owner or public)

### DIFF
--- a/server/adi-chat/src/main/java/com/moyz/adi/chat/controller/KnowledgeBaseEmbeddingController.java
+++ b/server/adi-chat/src/main/java/com/moyz/adi/chat/controller/KnowledgeBaseEmbeddingController.java
@@ -2,6 +2,7 @@ package com.moyz.adi.chat.controller;
 
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.moyz.adi.common.dto.KbItemEmbeddingDto;
+import com.moyz.adi.common.service.KnowledgeBaseItemService;
 import com.moyz.adi.common.service.embedding.IKnowledgeEmbeddingService;
 import jakarta.annotation.Resource;
 import org.springframework.validation.annotation.Validated;
@@ -18,8 +19,12 @@ public class KnowledgeBaseEmbeddingController {
     @Resource
     private IKnowledgeEmbeddingService iKnowledgeEmbeddingService;
 
+    @Resource
+    private KnowledgeBaseItemService knowledgeBaseItemService;
+
     @GetMapping("/list/{kbItemUuid}")
     public Page<KbItemEmbeddingDto> list(@PathVariable String kbItemUuid, int currentPage, int pageSize) {
+        knowledgeBaseItemService.checkReadPrivilegeByItem(kbItemUuid);
         return iKnowledgeEmbeddingService.listByItemUuid(kbItemUuid, currentPage, pageSize);
     }
 }

--- a/server/adi-chat/src/main/java/com/moyz/adi/chat/controller/KnowledgeBaseItemController.java
+++ b/server/adi-chat/src/main/java/com/moyz/adi/chat/controller/KnowledgeBaseItemController.java
@@ -31,10 +31,7 @@ public class KnowledgeBaseItemController {
 
     @GetMapping("/info/{uuid}")
     public KnowledgeBaseItem info(@PathVariable String uuid) {
-        return knowledgeBaseItemService.lambdaQuery()
-                .eq(KnowledgeBaseItem::getUuid, uuid)
-                .eq(KnowledgeBaseItem::getIsDeleted, false)
-                .one();
+        return knowledgeBaseItemService.info(uuid);
     }
 
     @PostMapping("/del/{uuid}")

--- a/server/adi-common/src/main/java/com/moyz/adi/common/service/KnowledgeBaseItemService.java
+++ b/server/adi-common/src/main/java/com/moyz/adi/common/service/KnowledgeBaseItemService.java
@@ -57,6 +57,10 @@ public class KnowledgeBaseItemService extends ServiceImpl<KnowledgeBaseItemMappe
     private KnowledgeBaseItemService self;
 
     @Resource
+    @Lazy
+    private KnowledgeBaseService knowledgeBaseService;
+
+    @Resource
     private StringRedisTemplate stringRedisTemplate;
 
     @Resource
@@ -101,9 +105,33 @@ public class KnowledgeBaseItemService extends ServiceImpl<KnowledgeBaseItemMappe
     }
 
     public Page<KbItemDto> search(String kbUuid, String keyword, Integer currentPage, Integer pageSize) {
+        knowledgeBaseService.checkReadPrivilege(kbUuid);
         Page<KbItemDto> page = baseMapper.searchByKb(new Page<>(currentPage, pageSize), kbUuid, keyword);
         page.getRecords().forEach(item -> item.setSourceFileUrl(fileService.getUrl(item.getSourceFileUuid())));
         return page;
+    }
+
+    /**
+     * Read authorization by knowledge-base item uuid: resolve the item's owning
+     * knowledge base and apply the owner/public read check.
+     */
+    public void checkReadPrivilegeByItem(String itemUuid) {
+        KnowledgeBaseItem item = lambdaQuery()
+                .eq(KnowledgeBaseItem::getUuid, itemUuid)
+                .eq(KnowledgeBaseItem::getIsDeleted, false)
+                .oneOpt().orElseThrow(() -> new BaseException(A_DATA_NOT_FOUND));
+        knowledgeBaseService.checkReadPrivilege(item.getKbUuid());
+    }
+
+    /**
+     * Fetch a knowledge-base item by uuid after a read-privilege check.
+     */
+    public KnowledgeBaseItem info(String uuid) {
+        checkReadPrivilegeByItem(uuid);
+        return lambdaQuery()
+                .eq(KnowledgeBaseItem::getUuid, uuid)
+                .eq(KnowledgeBaseItem::getIsDeleted, false)
+                .one();
     }
 
     /**

--- a/server/adi-common/src/main/java/com/moyz/adi/common/service/KnowledgeBaseService.java
+++ b/server/adi-common/src/main/java/com/moyz/adi/common/service/KnowledgeBaseService.java
@@ -658,6 +658,25 @@ public class KnowledgeBaseService extends ServiceImpl<KnowledgeBaseMapper, Knowl
     }
 
     /**
+     * Read authorization for a knowledge base's content: allow the owner, an admin,
+     * or anyone when the knowledge base is public. This mirrors the (owner-only)
+     * write-side checkPrivilege so that the read endpoints are scoped too. Denials
+     * are reported as A_DATA_NOT_FOUND to avoid leaking the existence of other
+     * users' private knowledge bases.
+     */
+    public void checkReadPrivilege(String kbUuid) {
+        KnowledgeBase kb = getOrThrow(kbUuid);
+        if (Boolean.TRUE.equals(kb.getIsPublic())) {
+            return;
+        }
+        User user = ThreadContext.getCurrentUser();
+        if (null != user && (Boolean.TRUE.equals(user.getIsAdmin()) || user.getId().equals(kb.getOwnerId()))) {
+            return;
+        }
+        throw new BaseException(A_DATA_NOT_FOUND);
+    }
+
+    /**
      * Set update knowledge base stat signal
      *
      * @param kbUuid 知识库uuid


### PR DESCRIPTION

Fixes #104

### Problem

The `/knowledge-base*` **read** endpoints returned another user's private knowledge-base content by item/KB UUID, because they carried no owner check — while the **write** paths are owner-scoped (`checkPrivilege` → `belongToUser`). There's also no global tenant scoping (no `TenantLineInnerInterceptor`) and `TokenFilter` only gates `/admin/**`, so any logged-in user could reach them:

- `GET /knowledge-base-embedding/list/{kbItemUuid}` → another user's RAG chunk text **and embedding vectors**
- `GET /knowledge-base-item/info/{uuid}` → full document text (`remark`)
- `GET /knowledge-base-item/search?kbUuid=` → document text, by KB

### Fix

Add `KnowledgeBaseService.checkReadPrivilege(kbUuid)` — allow the owner, an admin, or anyone when the KB is `is_public`; deny as `A_DATA_NOT_FOUND` so it doesn't leak the existence of other users' private KBs. Add a by-item variant in `KnowledgeBaseItemService` (resolve the item's KB, then check), and call them from the three read paths. This mirrors the existing write-side `checkPrivilege`, so legitimate access (your own KBs, and public KBs) is unchanged.

4 files, +53/-4 — no new dependencies.

### Verification (local build, v3.28.0)

Two users A and B; A creates a **private** KB and ingests a document.

Before:
```
B GET /knowledge-base-embedding/list/<A's item>  -> 200, A's chunk text + a 512-dim embedding vector
B GET /knowledge-base-item/info/<A's item>        -> 200, A's full document text
```
After this PR:
```
B GET /knowledge-base-embedding/list/<A's item>  -> 200, 0 records  (denied)
B GET /knowledge-base-item/info/<A's item>        -> 200, no content (denied)
A GET /knowledge-base-embedding/list/<A's item>  -> 200, 1 record   (owner still works)
```
(The write sibling already denied B and still does; A's own reads are unaffected.)

Found and fix verified with [Sectum AI](https://sectum.ai) — open-source multi-tenant isolation testing. Glad to adjust the approach (e.g. a global owner-scope interceptor) if you'd prefer.
