### PR TITLE
feat: 集成 You.com 联网搜索引擎并在 MCP 服务市场上架

### DIFF
--- a/server/adi-common/src/main/java/com/moyz/adi/common/cosntant/AdiConstant.java
+++ b/server/adi-common/src/main/java/com/moyz/adi/common/cosntant/AdiConstant.java
@@ -225,6 +225,7 @@ public class AdiConstant {
         public static final String OLLAMA_SETTING = "ollama_setting";
         public static final String SILICONFLOW_SETTING = "siliconflow_setting";
         public static final String GOOGLE_SETTING = "google_setting";
+        public static final String YOUCOM_SETTING = "youcom_setting";
         public static final String REQUEST_TEXT_RATE_LIMIT = "request_text_rate_limit";
         public static final String REQUEST_IMAGE_RATE_LIMIT = "request_image_rate_limit";
         public static final String CHARACTER_MAX_NUM = "character_max_num";
@@ -306,6 +307,8 @@ public class AdiConstant {
         }
 
         public static final String GOOGLE = "google";
+
+        public static final String YOUCOM = "youcom";
 
         public static final String[] GOOGLE_COUNTRIES = {"cn", "af", "al", "dz", "as", "ad", "ao", "ai", "aq", "ag", "ar", "am", "aw", "au", "at", "az", "bs", "bh", "bd", "bb", "by", "be", "bz", "bj", "bm", "bt", "bo", "ba", "bw", "bv", "br", "io", "bn", "bg", "bf", "bi", "kh", "cm", "ca", "cv", "ky", "cf", "td", "cl", "cx", "cc", "co", "km", "cg", "cd", "ck", "cr", "ci", "hr", "cu", "cy", "cz", "dk", "dj", "dm", "do", "ec", "eg", "sv", "gq", "er", "ee", "et", "fk", "fo", "fj", "fi", "fr", "gf", "pf", "tf", "ga", "gm", "ge", "de", "gh", "gi", "gr", "gl", "gd", "gp", "gu", "gt", "gn", "gw", "gy", "ht", "hm", "va", "hn", "hk", "hu", "is", "in", "id", "ir", "iq", "ie", "il", "it", "jm", "jp", "jo", "kz", "ke", "ki", "kp", "kr", "kw", "kg", "la", "lv", "lb", "ls", "lr", "ly", "li", "lt", "lu", "mo", "mk", "mg", "mw", "my", "mv", "ml", "mt", "mh", "mq", "mr", "mu", "yt", "mx", "fm", "md", "mc", "mn", "ms", "ma", "mz", "mm", "na", "nr", "np", "nl", "an", "nc", "nz", "ni", "ne", "ng", "nu", "nf", "mp", "no", "om", "pk", "pw", "ps", "pa", "pg", "py", "pe", "ph", "pn", "pl", "pt", "pr", "qa", "re", "ro", "ru", "rw", "sh", "kn", "lc", "pm", "vc", "ws", "sm", "st", "sa", "sn", "rs", "sc", "sl", "sg", "sk", "si", "sb", "so", "za", "gs", "es", "lk", "sd", "sr", "sj", "sz", "se", "ch", "sy", "tw", "tj", "tz", "th", "tl", "tg", "tk", "to", "tt", "tn", "tr", "tm", "tc", "tv", "ug", "ua", "ae", "uk", "gb", "us", "um", "uy", "uz", "vu", "ve", "vn", "vg", "vi", "wf", "eh", "ye", "zm", "zw"};
         public static final String[] GOOGLE_LANGUAGES = {"zh-cn", "zh-tw", "af", "ak", "sq", "ws", "am", "ar", "hy", "az", "eu", "be", "bem", "bn", "bh", "xx-bork", "bs", "br", "bg", "bt", "km", "ca", "chr", "ny", "co", "hr", "cs", "da", "nl", "xx-elmer", "en", "eo", "et", "ee", "fo", "tl", "fi", "fr", "fy", "gaa", "gl", "ka", "de", "el", "kl", "gn", "gu", "xx-hacker", "ht", "ha", "haw", "iw", "hi", "hu", "is", "ig", "id", "ia", "ga", "it", "ja", "jw", "kn", "kk", "rw", "rn", "xx-klingon", "kg", "ko", "kri", "ku", "ckb", "ky", "lo", "la", "lv", "ln", "lt", "loz", "lg", "ach", "mk", "mg", "ms", "ml", "mt", "mv", "mi", "mr", "mfe", "mo", "mn", "sr-me", "my", "ne", "pcm", "nso", "no", "nn", "oc", "or", "om", "ps", "fa", "xx-pirate", "pl", "pt", "pt-br", "pt-pt", "pa", "qu", "ro", "rm", "nyn", "ru", "gd", "sr", "sh", "st", "tn", "crs", "sn", "sd", "si", "sk", "sl", "so", "es", "es-419", "su", "sw", "sv", "tg", "ta", "tt", "te", "th", "ti", "to", "lua", "tum", "tr", "tk", "tw", "ug", "uk", "ur", "uz", "vu", "vi", "cy", "wo", "xh", "yi", "yo", "zu"};

--- a/server/adi-common/src/main/java/com/moyz/adi/common/searchengine/YouComSearchEngineService.java
+++ b/server/adi-common/src/main/java/com/moyz/adi/common/searchengine/YouComSearchEngineService.java
@@ -1,0 +1,109 @@
+package com.moyz.adi.common.searchengine;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.moyz.adi.common.cosntant.AdiConstant;
+import com.moyz.adi.common.dto.SearchReturn;
+import com.moyz.adi.common.dto.SearchReturnWebPage;
+import com.moyz.adi.common.interfaces.AbstractSearchEngineService;
+import com.moyz.adi.common.util.JsonUtil;
+import com.moyz.adi.common.vo.YouComSetting;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.moyz.adi.common.cosntant.AdiConstant.SysConfigKey.YOUCOM_SETTING;
+
+/**
+ * You.com web search(https://documentation.you.com), search endpoint: GET https://ydc-index.io/v1/search
+ * Auth: header X-API-Key
+ */
+@Slf4j
+public class YouComSearchEngineService extends AbstractSearchEngineService<YouComSetting> {
+
+    private static final int MAX_COUNT = 20;
+    private static final int DEFAULT_COUNT = 10;
+
+    public YouComSearchEngineService(InetSocketAddress proxy) {
+        super(AdiConstant.SearchEngineName.YOUCOM, YOUCOM_SETTING, YouComSetting.class, proxy);
+    }
+
+    @Override
+    protected void initSearchEngine() {
+        //No sdk/client to build, the http call is issued directly inside search()
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return null != setting && StringUtils.isNotBlank(setting.getKey());
+    }
+
+    @Override
+    public SearchReturn search(String searchTxt, String country, String language, Integer topN) {
+        SearchReturn result = new SearchReturn();
+        List<SearchReturnWebPage> items = new ArrayList<>();
+        result.setItems(items);
+        if (StringUtils.isBlank(searchTxt)) {
+            log.warn("youcom search terms is empty");
+            return result;
+        }
+        try {
+            int count = null == topN || topN <= 0 ? DEFAULT_COUNT : Math.min(topN, MAX_COUNT);
+            URI uri = UriComponentsBuilder.fromHttpUrl(setting.getUrl())
+                    .queryParam("query", searchTxt)
+                    .queryParam("count", count)
+                    .encode()
+                    .build()
+                    .toUri();
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("X-API-Key", setting.getKey());
+            HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+            ResponseEntity<String> response = getRestTemplate().exchange(uri, HttpMethod.GET, entity, String.class);
+            JsonNode root = JsonUtil.getObjectMapper().readTree(response.getBody());
+            JsonNode webResults = root.path("results").path("web");
+            if (webResults.isArray() && !webResults.isEmpty()) {
+                for (JsonNode item : webResults) {
+                    items.add(toWebPage(item));
+                }
+            } else {
+                log.warn("youcom search result is empty");
+            }
+        } catch (Exception e) {
+            log.error("youcom search error", e);
+        }
+        return result;
+    }
+
+    private SearchReturnWebPage toWebPage(JsonNode item) {
+        String title = item.path("title").asText("");
+        String link = item.path("url").asText("");
+        String snippet = item.path("description").asText("");
+        StringBuilder content = new StringBuilder();
+        JsonNode snippets = item.path("snippets");
+        if (snippets.isArray()) {
+            for (JsonNode s : snippets) {
+                if (!content.isEmpty()) {
+                    content.append("\n");
+                }
+                content.append(s.asText(""));
+            }
+        }
+        return SearchReturnWebPage.builder()
+                .title(title)
+                .link(link)
+                .snippet(snippet)
+                .content(content.toString())
+                .build();
+    }
+
+}

--- a/server/adi-common/src/main/java/com/moyz/adi/common/service/AiModelInitializer.java
+++ b/server/adi-common/src/main/java/com/moyz/adi/common/service/AiModelInitializer.java
@@ -14,6 +14,7 @@ import com.moyz.adi.common.helper.TtsModelContext;
 import com.moyz.adi.common.languagemodel.*;
 import com.moyz.adi.common.searchengine.GoogleSearchEngineService;
 import com.moyz.adi.common.searchengine.SearchEngineServiceContext;
+import com.moyz.adi.common.searchengine.YouComSearchEngineService;
 import jakarta.annotation.Resource;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
@@ -114,6 +115,7 @@ public class AiModelInitializer {
 
         //search engine
         SearchEngineServiceContext.addWebSearcher(AdiConstant.SearchEngineName.GOOGLE, new GoogleSearchEngineService(proxyAddress));
+        SearchEngineServiceContext.addWebSearcher(AdiConstant.SearchEngineName.YOUCOM, new YouComSearchEngineService(proxyAddress));
     }
 
     /**

--- a/server/adi-common/src/main/java/com/moyz/adi/common/vo/YouComSetting.java
+++ b/server/adi-common/src/main/java/com/moyz/adi/common/vo/YouComSetting.java
@@ -1,0 +1,9 @@
+package com.moyz.adi.common.vo;
+
+import lombok.Data;
+
+@Data
+public class YouComSetting {
+    private String url;
+    private String key;
+}

--- a/server/adi-common/src/test/java/com/moyz/adi/common/searchengine/YouComSearchEngineServiceTest.java
+++ b/server/adi-common/src/test/java/com/moyz/adi/common/searchengine/YouComSearchEngineServiceTest.java
@@ -1,0 +1,196 @@
+package com.moyz.adi.common.searchengine;
+
+import com.moyz.adi.common.cosntant.AdiConstant;
+import com.moyz.adi.common.dto.SearchReturn;
+import com.moyz.adi.common.dto.SearchReturnWebPage;
+import com.moyz.adi.common.util.LocalCache;
+import com.moyz.adi.common.util.SpringUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.mockito.Mockito;
+import org.springframework.context.ApplicationContext;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.queryParam;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * Offline unit tests for {@link YouComSearchEngineService}. All HTTP calls are stubbed via
+ * {@link MockRestServiceServer}; nothing here hits the real https://ydc-index.io endpoint.
+ * See {@link #liveSearch_realApi_returnsResults()} for the one gated live call.
+ */
+class YouComSearchEngineServiceTest {
+
+    private static final String URL = "https://ydc-index.io/v1/search";
+
+    private RestTemplate restTemplate;
+    private MockRestServiceServer mockServer;
+
+    @BeforeEach
+    void setUp() {
+        restTemplate = new RestTemplate();
+        mockServer = MockRestServiceServer.createServer(restTemplate);
+
+        ApplicationContext ctx = Mockito.mock(ApplicationContext.class);
+        Mockito.when(ctx.getBean(RestTemplate.class)).thenReturn(restTemplate);
+        new SpringUtil().setApplicationContext(ctx);
+
+        LocalCache.CONFIGS.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        LocalCache.CONFIGS.remove(AdiConstant.SysConfigKey.YOUCOM_SETTING);
+    }
+
+    private YouComSearchEngineService newService(String key) {
+        String json = "{\"url\":\"" + URL + "\",\"key\":\"" + key + "\"}";
+        LocalCache.CONFIGS.put(AdiConstant.SysConfigKey.YOUCOM_SETTING, json);
+        return new YouComSearchEngineService(null);
+    }
+
+    @Test
+    void isEnabled_whenKeyPresent_returnsTrue() {
+        assertThat(newService("test-key").isEnabled()).isTrue();
+    }
+
+    @Test
+    void isEnabled_whenKeyBlank_returnsFalse() {
+        assertThat(newService("").isEnabled()).isFalse();
+    }
+
+    @Test
+    void search_sendsApiKeyHeaderAndQueryParams() {
+        YouComSearchEngineService service = newService("secret-key");
+        mockServer.expect(requestTo(startsWithMatcher(URL)))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header("X-API-Key", "secret-key"))
+                .andExpect(queryParam("query", "hello%20world"))
+                .andExpect(queryParam("count", "7"))
+                .andRespond(withSuccess("{\"results\":{\"web\":[]}}", MediaType.APPLICATION_JSON));
+
+        SearchReturn result = service.search("hello world", null, null, 7);
+
+        assertThat(result.getItems()).isEmpty();
+        mockServer.verify();
+    }
+
+    @Test
+    void search_capsCountAt20() {
+        YouComSearchEngineService service = newService("secret-key");
+        mockServer.expect(requestTo(startsWithMatcher(URL)))
+                .andExpect(queryParam("count", "20"))
+                .andRespond(withSuccess("{\"results\":{\"web\":[]}}", MediaType.APPLICATION_JSON));
+
+        service.search("anything", null, null, 100);
+
+        mockServer.verify();
+    }
+
+    @Test
+    void search_defaultsCountWhenTopNMissing() {
+        YouComSearchEngineService service = newService("secret-key");
+        mockServer.expect(requestTo(startsWithMatcher(URL)))
+                .andExpect(queryParam("count", "10"))
+                .andRespond(withSuccess("{\"results\":{\"web\":[]}}", MediaType.APPLICATION_JSON));
+
+        service.search("anything", null, null, null);
+
+        mockServer.verify();
+    }
+
+    @Test
+    void search_mapsWebResultsIncludingMissingOptionalFields() {
+        YouComSearchEngineService service = newService("secret-key");
+        String body = "{\"results\":{\"web\":["
+                + "{\"title\":\"Title A\",\"url\":\"https://a.example\",\"description\":\"Desc A\",\"snippets\":[\"s1\",\"s2\"]},"
+                + "{\"title\":\"Title B\",\"url\":\"https://b.example\"}"
+                + "]}}";
+        mockServer.expect(requestTo(startsWithMatcher(URL)))
+                .andRespond(withSuccess(body, MediaType.APPLICATION_JSON));
+
+        SearchReturn result = service.search("hello", null, null, 5);
+
+        assertThat(result.getItems()).hasSize(2);
+        SearchReturnWebPage first = result.getItems().get(0);
+        assertThat(first.getTitle()).isEqualTo("Title A");
+        assertThat(first.getLink()).isEqualTo("https://a.example");
+        assertThat(first.getSnippet()).isEqualTo("Desc A");
+        assertThat(first.getContent()).isEqualTo("s1\ns2");
+
+        SearchReturnWebPage second = result.getItems().get(1);
+        assertThat(second.getTitle()).isEqualTo("Title B");
+        assertThat(second.getLink()).isEqualTo("https://b.example");
+        assertThat(second.getSnippet()).isEmpty();
+        assertThat(second.getContent()).isEmpty();
+    }
+
+    @Test
+    void search_blankQuery_returnsEmptyWithoutCallingApi() {
+        YouComSearchEngineService service = newService("secret-key");
+
+        SearchReturn result = service.search("   ", null, null, 5);
+
+        assertThat(result.getItems()).isEmpty();
+        mockServer.verify();
+    }
+
+    @Test
+    void search_serverError_returnsEmptyResultNeverThrows() {
+        YouComSearchEngineService service = newService("secret-key");
+        mockServer.expect(requestTo(startsWithMatcher(URL)))
+                .andRespond(withServerError());
+
+        SearchReturn result = service.search("hello", null, null, 5);
+
+        assertThat(result.getItems()).isEmpty();
+    }
+
+    @Test
+    void search_malformedJson_returnsEmptyResultNeverThrows() {
+        YouComSearchEngineService service = newService("secret-key");
+        mockServer.expect(requestTo(startsWithMatcher(URL)))
+                .andRespond(withSuccess("not-json", MediaType.APPLICATION_JSON));
+
+        SearchReturn result = service.search("hello", null, null, 5);
+
+        assertThat(result.getItems()).isEmpty();
+    }
+
+    private static org.hamcrest.Matcher<String> startsWithMatcher(String prefix) {
+        return org.hamcrest.Matchers.startsWith(prefix);
+    }
+
+    /**
+     * One real, network-hitting call. Skipped entirely unless YDC_API_KEY is exported
+     * (see ~/Desktop/you.com_projects/.env). Never runs as part of the default offline suite.
+     */
+    @Test
+    @EnabledIfEnvironmentVariable(named = "YDC_API_KEY", matches = ".+")
+    void liveSearch_realApi_returnsResults() {
+        String key = System.getenv("YDC_API_KEY");
+        RestTemplate realRestTemplate = new RestTemplate();
+        ApplicationContext ctx = Mockito.mock(ApplicationContext.class);
+        Mockito.when(ctx.getBean(RestTemplate.class)).thenReturn(realRestTemplate);
+        new SpringUtil().setApplicationContext(ctx);
+
+        String json = "{\"url\":\"" + URL + "\",\"key\":\"" + key + "\"}";
+        LocalCache.CONFIGS.put(AdiConstant.SysConfigKey.YOUCOM_SETTING, json);
+        YouComSearchEngineService service = new YouComSearchEngineService(null);
+
+        SearchReturn result = service.search("You.com API", null, null, 3);
+
+        assertThat(result.getErrorMessage()).isNull();
+        assertThat(result.getItems()).isNotEmpty();
+    }
+}

--- a/server/db_migration/011_youcom_search_and_mcp_cn.sql
+++ b/server/db_migration/011_youcom_search_and_mcp_cn.sql
@@ -1,0 +1,40 @@
+-- ============================================================
+-- Migration: 新增 You.com 网络搜索引擎服务商，以及 MCP 服务市场条目
+-- ============================================================
+
+-- 1. 网络搜索引擎配置（见 all_dml.sql，与 google_setting 保持一致的结构）
+-- https://documentation.you.com/api-reference/search
+INSERT INTO adi_sys_config (name, value)
+VALUES ('youcom_setting',
+        '{"url":"https://ydc-index.io/v1/search","key":""}');
+
+-- 2. MCP 服务市场条目，远程MCP服务器，提供AI原生的网络搜索能力（免费档，无需API密钥）
+-- You.com的端点使用的是streamable-HTTP传输协议，本项目内置的'sse'传输方式（基于GET的旧版SSE）
+-- 无法连接（已验证：直接GET请求会返回"405 Method Not Allowed: Use POST to send MCP requests"）。
+-- 因此这里通过stdio桥接方式`npx -y mcp-remote <url>`接入，与Brave Search的安装方式一致。
+insert into adi_mcp (uuid, title, transport_type, stdio_command, stdio_arg, install_type, website,
+                     remark, is_enable)
+values (replace(gen_random_uuid()::text, '-', ''), 'You.com', 'stdio', 'npx',
+        '-y mcp-remote https://api.you.com/mcp?profile=free', 'local',
+        'https://you.com',
+        '# You.com MCP 服务器
+
+远程 MCP 服务器，通过 You.com 提供 AI 原生的网络搜索能力。
+
+## 功能
+
+- **you-search**：网页与新闻搜索，支持按域名过滤（include_domains/exclude_domains）、
+  新鲜度过滤（day/week/month/year 或指定日期范围）、语言/国家选择，以及对命中页面的
+  可选实时抓取（markdown 或 HTML 格式）。
+
+## 免费档
+
+本条目使用 `profile=free` 端点（`https://api.you.com/mcp?profile=free`），无需 API 密钥，
+启用前无需任何配置。
+
+## 传输方式说明
+
+You.com 的 MCP 端点仅支持 streamable-HTTP 传输（直接 GET 请求会返回 "405 Method Not
+Allowed"）。由于本项目内置的 sse 传输方式依赖基于 GET 的事件流，因此这里改用 stdio 桥接
+`npx -y mcp-remote <url>` 的方式接入，与 Brave Search 的安装方式一致。',
+        true);

--- a/server/db_migration/011_youcom_search_and_mcp_en.sql
+++ b/server/db_migration/011_youcom_search_and_mcp_en.sql
@@ -1,0 +1,45 @@
+-- ============================================================
+-- Migration: Add You.com as a web search engine provider and as an MCP
+-- service market entry
+-- ============================================================
+
+-- 1. Web search engine provider setting (see all_dml.sql, mirrors google_setting)
+-- https://documentation.you.com/api-reference/search
+INSERT INTO adi_sys_config (name, value)
+VALUES ('youcom_setting',
+        '{"url":"https://ydc-index.io/v1/search","key":""}');
+
+-- 2. MCP service market entry, remote MCP server for AI-native web search
+-- (free profile, no API key required). You.com's endpoint speaks the
+-- streamable-HTTP MCP transport, which this project's built-in 'sse'
+-- transport (legacy GET-based SSE) cannot connect to (verified: a GET
+-- request returns "405 Method Not Allowed: Use POST to send MCP requests").
+-- It is connected here through the stdio bridge `npx -y mcp-remote <url>`,
+-- the same install shape already used for Brave Search.
+insert into adi_mcp (uuid, title, transport_type, stdio_command, stdio_arg, install_type, website,
+                     remark, is_enable)
+values (replace(gen_random_uuid()::text, '-', ''), 'You.com', 'stdio', 'npx',
+        '-y mcp-remote https://api.you.com/mcp?profile=free', 'local',
+        'https://you.com',
+        '# You.com MCP Server
+
+Remote MCP server providing AI-native web search via You.com.
+
+## Features
+
+- **you-search**: Web and news search with domain filtering (`include_domains`/`exclude_domains`),
+  freshness controls (day/week/month/year or a date range), language/country selection, and
+  optional live-crawl of matched pages (markdown or HTML).
+
+## Free profile
+
+This entry uses the `profile=free` endpoint (`https://api.you.com/mcp?profile=free`), which
+requires no API key -- no configuration is needed before enabling it.
+
+## Transport note
+
+You.com''s MCP endpoint only speaks the streamable-HTTP transport (a plain GET returns
+"405 Method Not Allowed"). Since this project''s built-in SSE transport expects a GET-based
+event stream, it is connected here via the stdio bridge `npx -y mcp-remote <url>` instead,
+mirroring how Brave Search is installed.',
+        true);

--- a/server/db_migration/all_dml.sql
+++ b/server/db_migration/all_dml.sql
@@ -12,6 +12,10 @@ VALUES ('catkeeper', '$2a$10$z44gncmQk6xCBCeDx55gMe1Zc8uYtOKcoT4/HE2F92VcF7wP2iq
 INSERT INTO adi_sys_config (name, value)
 VALUES ('google_setting',
         '{"url":"https://www.googleapis.com/customsearch/v1","key":"","cx":""}');
+-- https://documentation.you.com/api-reference/search
+INSERT INTO adi_sys_config (name, value)
+VALUES ('youcom_setting',
+        '{"url":"https://ydc-index.io/v1/search","key":""}');
 INSERT INTO adi_sys_config (name, value)
 VALUES ('request_text_rate_limit', '{"times":24,"minutes":3}');
 INSERT INTO adi_sys_config (name, value)

--- a/server/db_migration/all_dml_cn.sql
+++ b/server/db_migration/all_dml_cn.sql
@@ -485,3 +485,34 @@ values (replace(gen_random_uuid()::text, '-', ''), 1, 2, '[
     "encrypted": false
   }
 ]', true);
+
+-- You.com, 远程MCP服务器, 提供AI原生的网络搜索能力（免费档，无需API密钥）
+-- You.com的端点使用的是streamable-HTTP传输协议，本项目内置的'sse'传输方式（基于GET的旧版SSE）
+-- 无法连接（已验证：直接GET请求会返回"405 Method Not Allowed: Use POST to send MCP requests"）。
+-- 因此这里通过stdio桥接方式`npx -y mcp-remote <url>`接入，与上面Brave Search的安装方式一致。
+insert into adi_mcp (uuid, title, transport_type, stdio_command, stdio_arg, install_type, website,
+                     remark, is_enable)
+values (replace(gen_random_uuid()::text, '-', ''), 'You.com', 'stdio', 'npx',
+        '-y mcp-remote https://api.you.com/mcp?profile=free', 'local',
+        'https://you.com',
+        '# You.com MCP 服务器
+
+远程 MCP 服务器，通过 You.com 提供 AI 原生的网络搜索能力。
+
+## 功能
+
+- **you-search**：网页与新闻搜索，支持按域名过滤（include_domains/exclude_domains）、
+  新鲜度过滤（day/week/month/year 或指定日期范围）、语言/国家选择，以及对命中页面的
+  可选实时抓取（markdown 或 HTML 格式）。
+
+## 免费档
+
+本条目使用 `profile=free` 端点（`https://api.you.com/mcp?profile=free`），无需 API 密钥，
+启用前无需任何配置。
+
+## 传输方式说明
+
+You.com 的 MCP 端点仅支持 streamable-HTTP 传输（直接 GET 请求会返回 "405 Method Not
+Allowed"）。由于本项目内置的 sse 传输方式依赖基于 GET 的事件流，因此这里改用 stdio 桥接
+`npx -y mcp-remote <url>` 的方式接入，与上面 Brave Search 的安装方式一致。',
+        true);

--- a/server/db_migration/all_dml_en.sql
+++ b/server/db_migration/all_dml_en.sql
@@ -486,3 +486,36 @@ values (replace(gen_random_uuid()::text, '-', ''), 1, 2, '[
     "encrypted": false
   }
 ]', true);
+
+-- You.com, remote MCP server for AI-native web search (free profile, no API key required)
+-- You.com's endpoint speaks the streamable-HTTP MCP transport, which this project's built-in
+-- 'sse' transport (legacy GET-based SSE) cannot connect to (verified: a GET request returns
+-- "405 Method Not Allowed: Use POST to send MCP requests"). It is connected here through the
+-- stdio bridge `npx -y mcp-remote <url>`, the same install shape already used for Brave Search.
+insert into adi_mcp (uuid, title, transport_type, stdio_command, stdio_arg, install_type, website,
+                     remark, is_enable)
+values (replace(gen_random_uuid()::text, '-', ''), 'You.com', 'stdio', 'npx',
+        '-y mcp-remote https://api.you.com/mcp?profile=free', 'local',
+        'https://you.com',
+        '# You.com MCP Server
+
+Remote MCP server providing AI-native web search via You.com.
+
+## Features
+
+- **you-search**: Web and news search with domain filtering (`include_domains`/`exclude_domains`),
+  freshness controls (day/week/month/year or a date range), language/country selection, and
+  optional live-crawl of matched pages (markdown or HTML).
+
+## Free profile
+
+This entry uses the `profile=free` endpoint (`https://api.you.com/mcp?profile=free`), which
+requires no API key -- no configuration is needed before enabling it.
+
+## Transport note
+
+You.com''s MCP endpoint only speaks the streamable-HTTP transport (a plain GET returns
+"405 Method Not Allowed"). Since this project''s built-in SSE transport expects a GET-based
+event stream, it is connected here via the stdio bridge `npx -y mcp-remote <url>` instead,
+mirroring how Brave Search above is installed.',
+        true);


### PR DESCRIPTION
关联 Issue: https://github.com/moyangzhan/langchain4j-aideepin/issues/107

## 动机

aideepin 的联网搜索目前只内置 Google，MCP 服务市场也无联网搜索类条目。本 PR 一次交付两部分：**You.com 搜索引擎** 与 **MCP 市场条目**。纯增量，默认不启用，不影响现有功能。

## 变更内容

### 一、You.com 搜索引擎（adi-common）

- 新增 `YouComSearchEngineService`，完全参照现有 `GoogleSearchEngineService` 的策略模式：继承 `AbstractSearchEngineService<YouComSetting>`，通过 `getRestTemplate()` 调用 `GET https://ydc-index.io/v1/search`（`X-API-Key` 认证），结果映射为现有 `SearchReturnWebPage`（title / link / snippet / content）
- 新增 `YouComSetting`（url + key）、`SearchEngineName.YOUCOM`、`SysConfigKey.YOUCOM_SETTING` 常量
- 在 `AiModelInitializer` 中与 Google 并列注册（一行）
- 数量上限 20，异常降级为空结果绝不抛出，API Key 不出现在任何日志中；未配置 Key 时 `isEnabled()` 为 false
- 种子：`all_dml.sql` 新增 `youcom_setting` 系统配置（与 `google_setting` 同处），迁移脚本 `011_youcom_search_and_mcp_en/_cn.sql`

### 二、MCP 服务市场条目（种子数据）

- 在 `all_dml_en.sql` / `all_dml_cn.sql` 与迁移 `011` 中新增 You.com 市场条目
- **传输方式说明（已实测）**：You.com 的 MCP 端点只支持 streamable-HTTP（对其发 GET 会返回 `405 Method Not Allowed: Use POST to send MCP requests`），本项目内置的 `sse` 传输（旧式 GET-based SSE）无法直连。因此采用 stdio 桥接 `npx -y mcp-remote https://api.you.com/mcp?profile=free`（与现有 Brave Search 条目相同的安装形态）。已实测该桥接可完成 `initialize` + `tools/list` 握手（`Connected to remote server using StreamableHTTPClientTransport`），且免费 profile 无需 API Key。

## 测试

- 新增 `YouComSearchEngineServiceTest`：10 个用例（请求构造 X-API-Key/query/count、结果映射、空查询、异常降级为空不抛出、数量默认与上限等）——离线 9 个全过，1 个在线用例在未设置 `YDC_API_KEY` 时自动跳过，配置后实测通过（返回真实结果）
- adi-common 及全模块编译通过，离线测试与 main 基线对比零回归

```bash
cd server
mvn -pl adi-common -am test -Dtest='YouComSearchEngineServiceTest'
# 在线（可选，1 次真实调用）
export YDC_API_KEY=<你的 Key>   # 获取: https://you.com/platform/api-keys
```

## 备注

- 未新增独立的工作流节点：现有 `GoogleNode`/`GoogleNodeConfig` 把 `SearchEngineName.GOOGLE` 写死，是「每引擎一套」的实现，而非通用「可选引擎」节点。按 sheet 的字面需求，把 You.com 注册进 `SearchEngineServiceContext` 已满足（`/search-engine/list` 与工作流服务都通用消费）。如需要 You.com 专属工作流节点，可作为后续 PR。

---

**English summary**: Adds You.com two ways: (1) a web-search engine provider mirroring GoogleSearchEngineService (GET ydc-index.io/v1/search, X-API-Key, mapped to SearchReturnWebPage, registered in the search context, key-gated & disabled by default), and (2) an MCP service-market seed entry. Verified live that You.com's MCP speaks streamable-HTTP (a GET yields 405), which the repo's built-in sse transport can't reach — so it's wired through the stdio bridge `npx mcp-remote` (same shape as the existing Brave entry, free profile needs no key; handshake confirmed). 10 unit tests (9 offline + 1 gated live, verified against the real API), zero regressions. No new dependencies.
