### PR TITLE
fix(server): enforce knowledge-base read authorization on QA endpoints

### DIFF
--- a/server/adi-chat/src/main/java/com/moyz/adi/chat/controller/KnowledgeBaseQAController.java
+++ b/server/adi-chat/src/main/java/com/moyz/adi/chat/controller/KnowledgeBaseQAController.java
@@ -38,7 +38,7 @@ public class KnowledgeBaseQAController {
 
     @PostMapping("/add/{kbUuid}")
     public KbQaDto add(@PathVariable String kbUuid, @RequestBody @Validated QARecordReq req) {
-        KnowledgeBase knowledgeBase = knowledgeBaseService.getOrThrow(kbUuid);
+        KnowledgeBase knowledgeBase = knowledgeBaseService.getReadableOrThrow(kbUuid);
         return knowledgeBaseQaService.add(knowledgeBase, req);
     }
 
@@ -50,6 +50,7 @@ public class KnowledgeBaseQAController {
 
     @GetMapping("/search")
     public Page<KbQaDto> list(String kbUuid, String keyword, @NotNull @Min(1) Integer currentPage, @NotNull @Min(10) Integer pageSize) {
+        knowledgeBaseService.checkReadPrivilege(kbUuid);
         return knowledgeBaseQaService.search(kbUuid, keyword, currentPage, pageSize);
     }
 
@@ -60,11 +61,13 @@ public class KnowledgeBaseQAController {
 
     @GetMapping("/embedding-ref/{uuid}")
     public List<RefEmbeddingDto> embeddingRef(@PathVariable String uuid) {
+        knowledgeBaseService.getReadableQaOrThrow(uuid);
         return knowledgeBaseQaRecordReferenceService.listRefEmbeddings(uuid);
     }
 
     @GetMapping("/graph-ref/{uuid}")
     public RefGraphDto graphRef(@PathVariable String uuid) {
+        knowledgeBaseService.getReadableQaOrThrow(uuid);
         return knowledgeBaseQaRefGraphService.getByQaUuid(uuid);
     }
 

--- a/server/adi-common/src/main/java/com/moyz/adi/common/service/KnowledgeBaseService.java
+++ b/server/adi-common/src/main/java/com/moyz/adi/common/service/KnowledgeBaseService.java
@@ -410,6 +410,7 @@ public class KnowledgeBaseService extends ServiceImpl<KnowledgeBaseMapper, Knowl
     }
 
     public SseEmitter sseAsk(String qaRecordUuid) {
+        getReadableQaOrThrow(qaRecordUuid);
         checkRequestTimesOrThrow();
         String sseUuid = UuidUtil.createShort();
         SseEmitter sseEmitter = new SseEmitter(SSE_TIMEOUT);
@@ -842,6 +843,27 @@ public class KnowledgeBaseService extends ServiceImpl<KnowledgeBaseMapper, Knowl
     }
 
     /**
+     * Resolve a knowledge base only after checking whether the current user may read it.
+     * Keeping the lookup and authorization together prevents callers from accidentally
+     * resolving a private knowledge base before applying the read check.
+     */
+    public KnowledgeBase getReadableOrThrow(String kbUuid) {
+        KnowledgeBase knowledgeBase = getOrThrow(kbUuid);
+        ensureReadPrivilege(knowledgeBase);
+        return knowledgeBase;
+    }
+
+    /**
+     * Resolve a QA record and authorize access through its owning knowledge base.
+     * QA UUIDs are otherwise sufficient to reach private document references and answers.
+     */
+    public KnowledgeBaseQa getReadableQaOrThrow(String qaRecordUuid) {
+        KnowledgeBaseQa qaRecord = knowledgeBaseQaRecordService.getOrThrow(qaRecordUuid);
+        getReadableOrThrow(qaRecord.getKbUuid());
+        return qaRecord;
+    }
+
+    /**
      * Read authorization for a knowledge base's content: allow the owner, an admin,
      * or anyone when the knowledge base is public. This mirrors the (owner-only)
      * write-side checkWritePrivilege so that the read endpoints are scoped too. Denials
@@ -849,7 +871,10 @@ public class KnowledgeBaseService extends ServiceImpl<KnowledgeBaseMapper, Knowl
      * users' private knowledge bases.
      */
     public void checkReadPrivilege(String kbUuid) {
-        KnowledgeBase kb = getOrThrow(kbUuid);
+        ensureReadPrivilege(getOrThrow(kbUuid));
+    }
+
+    private void ensureReadPrivilege(KnowledgeBase kb) {
         if (Boolean.TRUE.equals(kb.getIsPublic())) {
             return;
         }

--- a/server/adi-common/src/test/java/com/moyz/adi/common/service/KnowledgeBaseServiceAuthorizationTest.java
+++ b/server/adi-common/src/test/java/com/moyz/adi/common/service/KnowledgeBaseServiceAuthorizationTest.java
@@ -1,0 +1,115 @@
+package com.moyz.adi.common.service;
+
+import com.moyz.adi.common.base.ThreadContext;
+import com.moyz.adi.common.entity.KnowledgeBase;
+import com.moyz.adi.common.entity.KnowledgeBaseQa;
+import com.moyz.adi.common.entity.User;
+import com.moyz.adi.common.enums.ErrorEnum;
+import com.moyz.adi.common.exception.BaseException;
+import com.moyz.adi.common.mapper.KnowledgeBaseMapper;
+import com.moyz.adi.common.util.SpringUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.MessageSource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class KnowledgeBaseServiceAuthorizationTest {
+
+    private KnowledgeBaseService knowledgeBaseService;
+    private KnowledgeBaseMapper knowledgeBaseMapper;
+    private KnowledgeBaseQaService knowledgeBaseQaService;
+
+    @BeforeEach
+    void setUp() {
+        knowledgeBaseService = new KnowledgeBaseService();
+        knowledgeBaseMapper = mock(KnowledgeBaseMapper.class);
+        knowledgeBaseQaService = mock(KnowledgeBaseQaService.class);
+        ApplicationContext applicationContext = mock(ApplicationContext.class);
+        MessageSource messageSource = mock(MessageSource.class);
+        when(applicationContext.getBean(MessageSource.class)).thenReturn(messageSource);
+        when(messageSource.getMessage(any(String.class), any(), any())).thenAnswer(invocation -> invocation.getArgument(0));
+        ReflectionTestUtils.setField(SpringUtil.class, "applicationContext", applicationContext);
+        ReflectionTestUtils.setField(knowledgeBaseService, "baseMapper", knowledgeBaseMapper);
+        ReflectionTestUtils.setField(knowledgeBaseService, "knowledgeBaseQaRecordService", knowledgeBaseQaService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        ThreadContext.unload();
+        ReflectionTestUtils.setField(SpringUtil.class, "applicationContext", null);
+    }
+
+    @Test
+    void privateKnowledgeBaseRejectsNonOwner() {
+        KnowledgeBase knowledgeBase = knowledgeBase(11L, 42L, false);
+        when(knowledgeBaseMapper.selectOne(any())).thenReturn(knowledgeBase);
+        ThreadContext.setCurrentUser(user(7L, false));
+
+        BaseException exception = assertThrows(BaseException.class,
+                () -> knowledgeBaseService.getReadableOrThrow("private-kb"));
+
+        assertEquals(ErrorEnum.A_DATA_NOT_FOUND.getCode(), exception.getCode());
+    }
+
+    @Test
+    void privateKnowledgeBaseAllowsOwnerAndAdmin() {
+        KnowledgeBase knowledgeBase = knowledgeBase(11L, 42L, false);
+        when(knowledgeBaseMapper.selectOne(any())).thenReturn(knowledgeBase);
+
+        ThreadContext.setCurrentUser(user(42L, false));
+        assertSame(knowledgeBase, knowledgeBaseService.getReadableOrThrow("private-kb"));
+
+        ThreadContext.setCurrentUser(user(7L, true));
+        assertSame(knowledgeBase, knowledgeBaseService.getReadableOrThrow("private-kb"));
+    }
+
+    @Test
+    void publicKnowledgeBaseAllowsAnyAuthenticatedUser() {
+        KnowledgeBase knowledgeBase = knowledgeBase(11L, 42L, true);
+        when(knowledgeBaseMapper.selectOne(any())).thenReturn(knowledgeBase);
+        ThreadContext.setCurrentUser(user(7L, false));
+
+        assertDoesNotThrow(() -> knowledgeBaseService.getReadableOrThrow("public-kb"));
+    }
+
+    @Test
+    void qaReadChecksTheOwningKnowledgeBase() {
+        KnowledgeBaseQa qaRecord = new KnowledgeBaseQa();
+        qaRecord.setKbUuid("private-kb");
+        when(knowledgeBaseQaService.getOrThrow("qa-record")).thenReturn(qaRecord);
+        when(knowledgeBaseMapper.selectOne(any())).thenReturn(knowledgeBase(11L, 42L, false));
+        ThreadContext.setCurrentUser(user(7L, false));
+
+        BaseException exception = assertThrows(BaseException.class,
+                () -> knowledgeBaseService.getReadableQaOrThrow("qa-record"));
+
+        assertEquals(ErrorEnum.A_DATA_NOT_FOUND.getCode(), exception.getCode());
+    }
+
+    private static KnowledgeBase knowledgeBase(Long id, Long ownerId, boolean isPublic) {
+        KnowledgeBase knowledgeBase = new KnowledgeBase();
+        knowledgeBase.setId(id);
+        knowledgeBase.setUuid("kb");
+        knowledgeBase.setOwnerId(ownerId);
+        knowledgeBase.setIsPublic(isPublic);
+        knowledgeBase.setIsDeleted(false);
+        return knowledgeBase;
+    }
+
+    private static User user(Long id, boolean isAdmin) {
+        User user = new User();
+        user.setId(id);
+        user.setIsAdmin(isAdmin);
+        return user;
+    }
+}


### PR DESCRIPTION
Closes #106

### What changed

- Require knowledge-base read access before creating QA records.
- Protect QA search, SSE processing, embedding references, and graph references.
- Reuse the existing owner/admin/public visibility rules.
- Return `A_DATA_NOT_FOUND` for unauthorized private knowledge-base access.
- Add unit tests for owner, admin, public, and QA-to-knowledge-base authorization.

### Verification

- `KnowledgeBaseServiceAuthorizationTest`: 4 tests passed
- `adi-chat` and dependencies compile successfully
- `git diff --check` passed